### PR TITLE
Support const string

### DIFF
--- a/src/TypedSignalR.Client.DevTools.Specification/SourceGenerator.cs
+++ b/src/TypedSignalR.Client.DevTools.Specification/SourceGenerator.cs
@@ -110,9 +110,16 @@ public sealed class SourceGenerator : IIncrementalGenerator
 
         if (symbol is IFieldSymbol field
             && field.IsConst
-            && field.ConstantValue is string value)
+            && field.ConstantValue is string fieldValue)
         {
-            return value;
+            return fieldValue;
+        }
+
+        if (symbol is ILocalSymbol local
+            && local.IsConst
+            && local.ConstantValue is string localValue)
+        {
+            return localValue;
         }
 
         return null;

--- a/src/TypedSignalR.Client.DevTools.Specification/SourceGenerator.cs
+++ b/src/TypedSignalR.Client.DevTools.Specification/SourceGenerator.cs
@@ -100,6 +100,12 @@ public sealed class SourceGenerator : IIncrementalGenerator
 
     private static string? GetPath(GeneratorSyntaxContext context, ExpressionSyntax syntax)
     {
+        if (syntax.Kind() == SyntaxKind.StringLiteralExpression
+            && syntax is LiteralExpressionSyntax literal)
+        {
+            return literal.Token.ValueText;
+        }
+
         var symbol = context.SemanticModel.GetSymbolInfo(syntax).Symbol;
 
         if (symbol is IFieldSymbol field
@@ -107,12 +113,6 @@ public sealed class SourceGenerator : IIncrementalGenerator
             && field.ConstantValue is string value)
         {
             return value;
-        }
-
-        if (syntax.Kind() == SyntaxKind.StringLiteralExpression
-            && syntax is LiteralExpressionSyntax literal)
-        {
-            return literal.Token.ValueText;
         }
 
         return null;

--- a/src/TypedSignalR.Client.DevTools.Specification/SourceGenerator.cs
+++ b/src/TypedSignalR.Client.DevTools.Specification/SourceGenerator.cs
@@ -81,13 +81,7 @@ public sealed class SourceGenerator : IIncrementalGenerator
             return default;
         }
 
-        if (arguments[0].Expression.Kind() != SyntaxKind.StringLiteralExpression)
-        {
-            return default;
-        }
-
-        var literal = arguments[0].Expression as LiteralExpressionSyntax;
-        var path = literal?.Token.ValueText;
+        var path = GetPath(context, arguments[0].Expression);
 
         if (string.IsNullOrEmpty(path))
         {
@@ -102,6 +96,26 @@ public sealed class SourceGenerator : IIncrementalGenerator
         }
 
         return new SourceSymbol(methodSymbol, target.GetLocation(), path!);
+    }
+
+    private static string? GetPath(GeneratorSyntaxContext context, ExpressionSyntax syntax)
+    {
+        var symbol = context.SemanticModel.GetSymbolInfo(syntax).Symbol;
+
+        if (symbol is IFieldSymbol field
+            && field.IsConst
+            && field.ConstantValue is string value)
+        {
+            return value;
+        }
+
+        if (syntax.Kind() == SyntaxKind.StringLiteralExpression
+            && syntax is LiteralExpressionSyntax literal)
+        {
+            return literal.Token.ValueText;
+        }
+
+        return null;
     }
 
     private static ValidatedSourceSymbol ValidateMapHubMethodSymbol((SourceSymbol, SpecialSymbols) pair, CancellationToken cancellationToken)


### PR DESCRIPTION
Related: #45 

Support statements such as the following.

```cs
// Program.cs

app.MapHub<ChatHub>(Foo.Path);

app.Run();

public static class Foo
{
    public const string Path = "/hubs/ChatHub";
}
```

```cs
// Program.cs

const string Path = "/hubs/chathub";

app.MapHub<ChatHub>(Path);

app.Run();
```